### PR TITLE
Remove `urlencoding` dependency and simplify crypto implementation by…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "confirm-email"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -156,7 +156,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "urlencoding",
 ]
 
 [[package]]
@@ -482,12 +481,6 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
-
-[[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "confirm-email"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 rust-version = "1.85.1"
 description = """
@@ -23,7 +23,6 @@ chrono = "0.4.41"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 thiserror = "2.0.12"
-urlencoding = "2.1.3"
 
 [lib]
 name = "confirm_email"

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -6,15 +6,15 @@ use aes_gcm::{Aes128Gcm, Key, KeyInit, Nonce};
 use argon2::password_hash::SaltString;
 use argon2::{Argon2, PasswordHasher};
 use base64::Engine;
-use base64::engine::general_purpose;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 
 // Derive key from password using Argon2id
 fn derive_key(password: &str, salt: &[u8]) -> Result<[u8; 16], Error> {
     let argon2 = Argon2::default();
-    let salt_string = SaltString::encode_b64(salt).map_err(|e| Other(format!("{:}", e)))?;
+    let salt_string = SaltString::encode_b64(salt).map_err(|e| Other(format!("{e:#?}")))?;
     let password_hash = argon2
         .hash_password(password.as_bytes(), &salt_string)
-        .map_err(|e| Other(format!("{:}", e)))?;
+        .map_err(|e| Other(format!("{e:#?}")))?;
     let hash_bytes = password_hash
         .hash
         .ok_or(Other("Failed to generate the hash".to_string()))?;
@@ -33,7 +33,7 @@ pub fn encrypt(enc_key: &str, plaintext: &str) -> Result<String, Error> {
     OsRng.fill_bytes(&mut nonce_bytes);
 
     // Derive key from password
-    let key_bytes = derive_key(enc_key, &salt).map_err(|e| Other(format!("{:}", e)))?;
+    let key_bytes = derive_key(enc_key, &salt).map_err(|e| Other(format!("{e:#?}")))?;
     let key = Key::<Aes128Gcm>::from_slice(&key_bytes);
     let cipher = Aes128Gcm::new(key);
     let nonce = Nonce::from_slice(&nonce_bytes);
@@ -41,7 +41,7 @@ pub fn encrypt(enc_key: &str, plaintext: &str) -> Result<String, Error> {
     // Encrypt the plaintext
     let ciphertext = cipher
         .encrypt(nonce, plaintext.as_bytes())
-        .map_err(|e| Other(format!("{:}", e)))?;
+        .map_err(|e| Other(format!("{e:#?}")))?;
 
     // Combine salt + nonce + ciphertext and encode as base64
     let mut result = Vec::new();
@@ -49,15 +49,15 @@ pub fn encrypt(enc_key: &str, plaintext: &str) -> Result<String, Error> {
     result.extend_from_slice(&nonce_bytes);
     result.extend_from_slice(&ciphertext);
 
-    Ok(general_purpose::STANDARD.encode(result))
+    Ok(URL_SAFE_NO_PAD.encode(result))
 }
 
 // Decrypt string with password
 pub fn decrypt(enc_key: &str, encrypted_data: &str) -> Result<String, Error> {
     // Decode from base64
-    let data = general_purpose::STANDARD
+    let data = URL_SAFE_NO_PAD
         .decode(encrypted_data)
-        .map_err(|e| Other(format!("{:}", e)))?;
+        .map_err(|e| Other(format!("{e:#?}")))?;
 
     if data.len() < 28 {
         return Err(Other("Invalid encrypted data".to_string()));
@@ -69,7 +69,7 @@ pub fn decrypt(enc_key: &str, encrypted_data: &str) -> Result<String, Error> {
     let ciphertext = &data[28..];
 
     // Derive key from password
-    let key_bytes = derive_key(enc_key, salt).map_err(|e| Other(format!("{:}", e)))?;
+    let key_bytes = derive_key(enc_key, salt).map_err(|e| Other(format!("{e:#?}")))?;
     let key = Key::<Aes128Gcm>::from_slice(&key_bytes);
     let cipher = Aes128Gcm::new(key);
     let nonce = Nonce::from_slice(nonce_bytes);
@@ -77,6 +77,6 @@ pub fn decrypt(enc_key: &str, encrypted_data: &str) -> Result<String, Error> {
     // Decrypt the ciphertext
     let plaintext = cipher
         .decrypt(nonce, ciphertext)
-        .map_err(|e| Other(format!("{:}", e)))?;
-    String::from_utf8(plaintext).map_err(|e| Other(format!("{:}", e)))
+        .map_err(|e| Other(format!("{e:#?}")))?;
+    String::from_utf8(plaintext).map_err(|e| Other(format!("{e:#?}")))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,10 +91,10 @@ fn generate(email: String, key: String, exp: Duration) -> Result<String, Error> 
 
     let payload = Payload { email, expiration };
 
-    let json = serde_json::to_string(&payload).map_err(|e| Other(format!("{:}", e)))?;
+    let json = serde_json::to_string(&payload).map_err(|e| Other(format!("{e:#?}")))?;
     let data = encrypt(key.as_str(), json.as_str())?;
 
-    Ok(urlencoding::encode(data.as_str()).to_string())
+    Ok(data)
 }
 
 #[inline]
@@ -188,12 +188,10 @@ pub fn generate_token(email: String, key: String) -> Result<String, Error> {
 /// assert_eq!(validate_token(token, "secret_key".to_string()).unwrap(), "user@example.com");
 /// ```
 pub fn validate_token(token: String, key: String) -> Result<String, Error> {
-    let decoded = urlencoding::decode(token.as_str()).map_err(|e| Other(format!("{:}", e)))?;
-
-    let decrypted = decrypt(key.as_str(), decoded.as_ref())?;
+    let decrypted = decrypt(key.as_str(), token.as_str())?;
 
     let payload: Payload =
-        serde_json::from_str(decrypted.as_str()).map_err(|e| Other(format!("{:}", e)))?;
+        serde_json::from_str(decrypted.as_str()).map_err(|e| Other(format!("{e:#?}")))?;
 
     let exp = match Utc.timestamp_opt(payload.expiration, 0).single() {
         None => {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,5 +1,9 @@
 use crate::error::Error;
 use crate::{generate_token, generate_token_with_expiration, validate_token};
+use aes_gcm::aead::OsRng;
+use argon2::password_hash::rand_core::RngCore;
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use std::thread;
 use std::time::Duration;
 
@@ -36,7 +40,26 @@ fn expired_token_test() {
     thread::sleep(Duration::from_secs(3));
 
     let expired = validate_token(token.unwrap(), KEY.to_string());
-    assert!(matches!(expired, Err(Error::Expired(_))));
+    assert!(matches!(expired, Err(Error::Expired(_))))
 
     // assert_matches!(expired, Err(Error::Expired(_))); // unstable
+}
+
+#[test]
+fn invalid_key_test() {
+    let token = generate_token(EMAIL.to_string(), KEY.to_string());
+    assert!(token.is_ok());
+
+    let error = validate_token(token.unwrap(), "wrong_key".to_string());
+    assert!(error.is_err())
+}
+
+#[test]
+fn invalid_token_test() {
+    let mut bytes = vec![0u8; 64];
+    OsRng.fill_bytes(&mut bytes);
+
+    let invalid_token = URL_SAFE_NO_PAD.encode(&bytes);
+    let error = validate_token(invalid_token, "wrong_key".to_string());
+    assert!(error.is_err())
 }


### PR DESCRIPTION
Remove `urlencoding` dependency and simplify crypto implementation by using built-in base64 URL-safe encoding instead. Also improve error reporting.

- Removed `urlencoding` crate from dependencies
- Switched to using `base64::URL_SAFE_NO_PAD` for encoding/decoding
- Improved error messages with more detailed debug information
- Added new tests for invalid key and token cases